### PR TITLE
precompile regular expressions for a ~4x speedup

### DIFF
--- a/english/main.go
+++ b/english/main.go
@@ -120,8 +120,9 @@ func (a *MultiPunctWordAnnotation) Annotate(tokens []*sentences.Token) []*senten
 	return tokens
 }
 
+var reAbbr = regexp.MustCompile(`((?:[\w]\.)+[\w]*\.)`)
+
 func (a *MultiPunctWordAnnotation) tokenAnnotation(tokOne, tokTwo *sentences.Token) {
-	reAbbr := regexp.MustCompile(`((?:[\w]\.)+[\w]*\.)`)
 	if len(reAbbr.FindAllString(tokOne.Tok, 1)) == 0 {
 		return
 	}

--- a/punctuation.go
+++ b/punctuation.go
@@ -1,10 +1,14 @@
 package sentences
 
+import (
+	"regexp"
+)
+
 // PunctStrings implements all the functions necessary for punctuation strings.
 // They are used to detect punctuation in the sentence
 // tokenizer.
 type PunctStrings interface {
-	NonPunct() string
+	NonPunct() *regexp.Regexp
 	Punctuation() string
 	HasSentencePunct(string) bool
 }
@@ -18,9 +22,10 @@ func NewPunctStrings() *DefaultPunctStrings {
 	return &DefaultPunctStrings{}
 }
 
-// NonPunct regex string to detect non-punctuation.
-func (p *DefaultPunctStrings) NonPunct() string {
-	return `[^\W\d]`
+var nonPunctRegex = regexp.MustCompile(`[^\W\d]`)
+
+func (p *DefaultPunctStrings) NonPunct() *regexp.Regexp {
+	return nonPunctRegex
 }
 
 // Punctuation characters

--- a/token.go
+++ b/token.go
@@ -2,7 +2,6 @@ package sentences
 
 import (
 	"fmt"
-	"regexp"
 )
 
 // TokenGrouper two adjacent tokens together.
@@ -43,20 +42,12 @@ type Token struct {
 	LineStart   bool
 	Abbr        bool
 	periodFinal bool
-	reEllipsis  *regexp.Regexp
-	reNumeric   *regexp.Regexp
-	reInitial   *regexp.Regexp
-	reAlpha     *regexp.Regexp
 }
 
 // NewToken is the default implementation of the Token struct
 func NewToken(token string) *Token {
 	tok := Token{
-		Tok:        token,
-		reEllipsis: regexp.MustCompile(`\.\.+$`),
-		reNumeric:  regexp.MustCompile(`-?[\.,]?\d[\d,\.-]*\.?$`),
-		reInitial:  regexp.MustCompile(`^[A-Za-z]\.$`),
-		reAlpha:    regexp.MustCompile(`^[A-Za-z]+$`),
+		Tok: token,
 	}
 
 	return &tok

--- a/word_tokenizer.go
+++ b/word_tokenizer.go
@@ -6,6 +6,11 @@ import (
 	"unicode"
 )
 
+var reEllipsis = regexp.MustCompile(`\.\.+$`)
+var reNumeric = regexp.MustCompile(`-?[\.,]?\d[\d,\.-]*\.?$`)
+var reInitial = regexp.MustCompile(`^[A-Za-z]\.$`)
+var reAlpha = regexp.MustCompile(`^[A-Za-z]+$`)
+
 // WordTokenizer is the primary interface for tokenizing words
 type WordTokenizer interface {
 	TokenParser
@@ -130,7 +135,7 @@ func (p *DefaultWordTokenizer) Tokenize(text string, onlyPeriodContext bool) []*
 
 // Type returns a case-normalized representation of the token.
 func (p *DefaultWordTokenizer) Type(t *Token) string {
-	typ := t.reNumeric.ReplaceAllString(strings.ToLower(t.Tok), "##number##")
+	typ := reNumeric.ReplaceAllString(strings.ToLower(t.Tok), "##number##")
 	if len(typ) == 1 {
 		return typ
 	}
@@ -183,7 +188,7 @@ func (p *DefaultWordTokenizer) FirstLower(t *Token) bool {
 
 // IsEllipsis is true if the token text is that of an ellipsis.
 func (p *DefaultWordTokenizer) IsEllipsis(t *Token) bool {
-	return t.reEllipsis.MatchString(t.Tok)
+	return reEllipsis.MatchString(t.Tok)
 }
 
 // IsNumber is true if the token text is that of a number.
@@ -193,18 +198,17 @@ func (p *DefaultWordTokenizer) IsNumber(t *Token) bool {
 
 // IsInitial is true if the token text is that of an initial.
 func (p *DefaultWordTokenizer) IsInitial(t *Token) bool {
-	return t.reInitial.MatchString(t.Tok)
+	return reInitial.MatchString(t.Tok)
 }
 
 // IsAlpha is true if the token text is all alphabetic.
 func (p *DefaultWordTokenizer) IsAlpha(t *Token) bool {
-	return t.reAlpha.MatchString(t.Tok)
+	return reAlpha.MatchString(t.Tok)
 }
 
 // IsNonPunct is true if the token is either a number or is alphabetic.
 func (p *DefaultWordTokenizer) IsNonPunct(t *Token) bool {
-	nonPunct := regexp.MustCompile(p.PunctStrings.NonPunct())
-	return nonPunct.MatchString(p.Type(t))
+	return p.PunctStrings.NonPunct().MatchString(p.Type(t))
 }
 
 // HasPeriodFinal is true if the last character in the word is a period


### PR DESCRIPTION
a hack to precompile regular expressions at application startup time.  For unit tests:

before:
```
ok  	github.com/neurosnap/sentences	0.163s
```
after:
```
ok  	github.com/neurosnap/sentences	0.040s
```
about a 4x speedup.

Then in a more real world test I integrated this into a program that processes text in 150k documents of approximately 4kb a piece.  Can't share the corpus unfortunately cuz it's not public.  but before:
```
real	1m35.864s
user	16m13.703s
sys	0m8.947s
```

after:
```
real	0m15.041s
user	2m0.930s
sys	0m1.777s
```

8x less cpu used!