### PR TITLE
Fix for word tokenizer dropping last word in input.

### DIFF
--- a/word_tokenizer.go
+++ b/word_tokenizer.go
@@ -76,9 +76,8 @@ func (p *DefaultWordTokenizer) Tokenize(text string, onlyPeriodContext bool) []*
 	lineStart := false
 	paragraphStart := false
 	getNextWord := false
-
 	for i, char := range text {
-		if !unicode.IsSpace(char) {
+		if !unicode.IsSpace(char) && i != len(text)-1 {
 			continue
 		}
 
@@ -88,8 +87,13 @@ func (p *DefaultWordTokenizer) Tokenize(text string, onlyPeriodContext bool) []*
 			}
 			lineStart = true
 		}
+		var word string
+		if i == len(text)-1 {
+			word = strings.TrimSpace(text[lastSpace:])
+		} else {
+			word = strings.TrimSpace(text[lastSpace:i])
+		}
 
-		word := strings.TrimSpace(text[lastSpace:i])
 		if word == "" {
 			continue
 		}


### PR DESCRIPTION
Currently, the word tokenizer fails to return the last token in a given string. For example, "This is a test sentence" is output as {This is a test}. The problem occurs in line 81, where the loop continues if it is not a space. I added a condition there to only continue if the current character is not the last in the input.

Lines 90-95 just handle the case appropriately where i is the last character; if it is the last character then we want text[lastSpace:], otherwise text[len(text)-1] never has the opportunity to be included in a token, and so if we don't do that "This is a test sentence" comes out as {This is a test sentenc}.

The TravisCI build is currently failing but this is due to the sentence tokenizer which I did not alter.

I'm hoping to write some tests and benchmarks for the word tokenizer, but I thought I'd get the bugfix out ASAP in case others are affected.

Cheers!