### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/utils/frequency_dist.go
+++ b/utils/frequency_dist.go
@@ -22,7 +22,7 @@ func NewFreqDist(samples map[string]int) *FreqDist {
 	return &FreqDist{samples}
 }
 
-// Return the total number of sample outcomes that have been recorded by this FreqDist.
+// N returns the total number of sample outcomes that have been recorded by this FreqDist.
 func (f *FreqDist) N() float64 {
 	sum := 0.0
 	for _, val := range f.Samples {
@@ -31,7 +31,7 @@ func (f *FreqDist) N() float64 {
 	return sum
 }
 
-// Return the total number of sample values (or "bins") that have counts greater than zero.
+// B returns the total number of sample values (or "bins") that have counts greater than zero.
 func (f *FreqDist) B() int {
 	return len(f.Samples)
 }


### PR DESCRIPTION
Hi, I've changed these public function comments to comply with [this standard](https://golang.org/doc/effective_go.html#commentary) in Effective Go. It's admittedly a small fix but I hope it helps!