### PR TITLE
 feat: add fullwidth punctuation to support CJK

### DIFF
--- a/punctuation.go
+++ b/punctuation.go
@@ -25,12 +25,12 @@ func (p *DefaultPunctStrings) NonPunct() string {
 
 // Punctuation characters
 func (p *DefaultPunctStrings) Punctuation() string {
-	return ";:,.!?"
+	return ";:,.!?；：，。！？"
 }
 
 // HasSentencePunct does the supplied text have a known sentence punctuation character?
 func (p *DefaultPunctStrings) HasSentencePunct(text string) bool {
-	endPunct := `.!?`
+	endPunct := `.!?。！？`
 	for _, char := range endPunct {
 		for _, achar := range text {
 			if char == achar {

--- a/word_tokenizer.go
+++ b/word_tokenizer.go
@@ -80,7 +80,7 @@ func (p *DefaultWordTokenizer) Tokenize(text string, onlyPeriodContext bool) []*
 	getNextWord := false
 
 	for i, char := range text {
-		if !unicode.IsSpace(char) && i != textLength - 1 {
+		if !unicode.IsSpace(char) && i != textLength-1 {
 			continue
 		}
 
@@ -92,7 +92,7 @@ func (p *DefaultWordTokenizer) Tokenize(text string, onlyPeriodContext bool) []*
 		}
 
 		var cursor int
-		if i == textLength - 1 {
+		if i == textLength-1 {
 			cursor = textLength
 		} else {
 			cursor = i
@@ -217,7 +217,7 @@ func (p *DefaultWordTokenizer) IsNonPunct(t *Token) bool {
 
 // HasPeriodFinal is true if the last character in the word is a period
 func (p *DefaultWordTokenizer) HasPeriodFinal(t *Token) bool {
-	return strings.HasSuffix(t.Tok, ".")
+	return strings.HasSuffix(t.Tok, ".") || strings.HasSuffix(t.Tok, "。")
 }
 
 // HasSentEndChars finds any punctuation excluding the period final
@@ -226,6 +226,9 @@ func (p *DefaultWordTokenizer) HasSentEndChars(t *Token) bool {
 		`."`, `.'`, `.)`,
 		`?`, `?"`, `?'`, `?)`,
 		`!`, `!"`, `!'`, `!)`, `!’`, `!”`,
+		`。”`, `。’`, `。）`,
+		`？`, `？”`, `？’`, `？）`,
+		`！`, `！”`, `！’`, `！）`, `！’`, `！”`,
 	}
 
 	for _, ender := range enders {
@@ -238,6 +241,9 @@ func (p *DefaultWordTokenizer) HasSentEndChars(t *Token) bool {
 		`.[`, `.(`, `."`, `.'`,
 		`?[`, `?(`,
 		`![`, `!(`,
+		`。【`, `。（`, `。”`, `。’`,
+		`？【`, `？（`,
+		`！【`, `！（`,
 	}
 
 	for _, paren := range parens {

--- a/word_tokenizer.go
+++ b/word_tokenizer.go
@@ -80,8 +80,12 @@ func (p *DefaultWordTokenizer) Tokenize(text string, onlyPeriodContext bool) []*
 	getNextWord := false
 
 	for i, char := range text {
-		if !unicode.IsSpace(char) && i != textLength-1 {
+		if !unicode.IsSpace(char) && !IsCjkPunct(char) && i != textLength-1 {
 			continue
+		}
+
+		if IsCjkPunct(char) {
+			i += len(string(char))
 		}
 
 		if char == '\n' {
@@ -252,5 +256,13 @@ func (p *DefaultWordTokenizer) HasSentEndChars(t *Token) bool {
 		}
 	}
 
+	return false
+}
+
+func IsCjkPunct(r rune) bool {
+	switch r {
+	case '。', '；', '！', '？':
+		return true
+	}
 	return false
 }


### PR DESCRIPTION
I tried to add fullwidth punctuation and now it seems to work well for CJK.
Here is my test code:

```go
package main

import (
	"fmt"

	"gopkg.in/wzru/sentences.v1"
	"gopkg.in/wzru/sentences.v1/data"
)

func main() {
	var text string

	// Compiling language specific data into a binary file can be accomplished
	// by using `make <lang>` and then loading the `json` data:
	b, _ := data.Asset("data/english.json")

	// load the training data
	training, _ := sentences.LoadTraining(b)

	// create the default sentence tokenizer
	tokenizer := sentences.NewSentenceTokenizer(training)

	text = `你好。世界！` //Hello world
	sentences := tokenizer.Tokenize(text)
	for _, s := range sentences {
		fmt.Printf("'%s'\n", s.Text)
	}

	text = `你好吗？我很好。很高兴见到你！`
	// text = `How are you? i'm fine. Nice to meet you!`
	sentences = tokenizer.Tokenize(text)
	for _, s := range sentences {
		fmt.Printf("'%s'\n", s.Text)
	}
}
```

output:
```bash
$ go run main.go
'你好。'
'世界！'
'你好吗？'
'我很好。'
'很高兴见到你！'