### PR TITLE
Fix imports in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ go get github.com/neurosnap/sentences
 ```Go
 import (
     "fmt"
+    "os"
 
     "github.com/neurosnap/sentences"
-    "github.com/neurosnap/sentences/data"
 )
 
 func main() {


### PR DESCRIPTION
It looks like [this commit](https://github.com/neurosnap/sentences/commit/24b047a992a69e838d6c690e311806d2f9029823) changed the necessary imports for this code snippet — this should fix it