### PR TITLE
fix sentence breaks in lists: add check for list numbers

### DIFF
--- a/english/golden_rules_test.go
+++ b/english/golden_rules_test.go
@@ -60,4 +60,28 @@ func TestGoldenRules(t *testing.T) {
 		" She held the book out to show him.",
 	}
 	compareSentences(t, actualText, expected, test)
+
+	test = "32. List (period followed by parens and period to end item)"
+	actualText = "1.) The first item. 2.) The second item."
+	expected = []string{
+		"1.) The first item.",
+		" 2.) The second item.",
+	}
+	compareSentences(t, actualText, expected, test)
+
+	test = "34. List (parens and period to end item)"
+	actualText = "1) The first item. 2) The second item."
+	expected = []string{
+		"1) The first item.",
+		" 2) The second item.",
+	}
+	compareSentences(t, actualText, expected, test)
+
+	test = "36. List (period to mark list and period to end item)"
+	actualText = "1. The first item. 2. The second item."
+	expected = []string{
+		"1. The first item.",
+		" 2. The second item.",
+	}
+	compareSentences(t, actualText, expected, test)
 }

--- a/english/main.go
+++ b/english/main.go
@@ -136,6 +136,11 @@ func (a *MultiPunctWordAnnotation) Annotate(tokens []*sentences.Token) []*senten
 }
 
 func (a *MultiPunctWordAnnotation) tokenAnnotation(tokOne, tokTwo *sentences.Token) {
+	if a.IsListNumber(tokOne) {
+		tokOne.SentBreak = false
+		return
+	}
+
 	if len(reAbbr.FindAllString(tokOne.Tok, 1)) == 0 && !a.HasUnreliableEndChars(tokOne) {
 		return
 	}

--- a/token.go
+++ b/token.go
@@ -46,12 +46,14 @@ type Token struct {
 	reEllipsis  *regexp.Regexp
 	reNumeric   *regexp.Regexp
 	reInitial   *regexp.Regexp
+	reListNumber *regexp.Regexp
 	reAlpha     *regexp.Regexp
 }
 
 var reEllipsis = regexp.MustCompile(`\.\.+$`)
 var reNumeric = regexp.MustCompile(`-?[\.,]?\d[\d,\.-]*\.?$`)
 var reInitial = regexp.MustCompile(`^[A-Za-z]\.$`)
+var reListNumber = regexp.MustCompile(`\d+.?\)?$`)
 var reAlpha = regexp.MustCompile(`^[A-Za-z]+$`)
 
 // NewToken is the default implementation of the Token struct
@@ -61,6 +63,7 @@ func NewToken(token string) *Token {
 		reEllipsis: reEllipsis,
 		reNumeric:  reNumeric,
 		reInitial:  reInitial,
+		reListNumber: reListNumber,
 		reAlpha:    reAlpha,
 	}
 

--- a/word_tokenizer.go
+++ b/word_tokenizer.go
@@ -37,6 +37,8 @@ type TokenExistential interface {
 	IsEllipsis(*Token) bool
 	// True if the token text is that of an initial.
 	IsInitial(*Token) bool
+	// True if the token text is that of an number as part of a list.
+	IsListNumber(*Token) bool
 	// True if the token text is that of a number.
 	IsNumber(*Token) bool
 	// True if the token is either a number or is alphabetic.
@@ -209,6 +211,11 @@ func (p *DefaultWordTokenizer) IsNumber(t *Token) bool {
 // IsInitial is true if the token text is that of an initial.
 func (p *DefaultWordTokenizer) IsInitial(t *Token) bool {
 	return t.reInitial.MatchString(t.Tok)
+}
+
+// IsInitial is true if the token text is that of a list number.
+func (p *DefaultWordTokenizer) IsListNumber(t *Token) bool {
+	return t.reListNumber.MatchString(t.Tok)
 }
 
 // IsAlpha is true if the token text is all alphabetic.


### PR DESCRIPTION
This PR fixes some more of the golden rules sentences from issue #10. The affected tests are the ones containing lists. The PR fixes them by adding the check if a token is a number followed by a point, a brace, or both (for example 1. or 1.) or 1) ) In this case, there is no sentence break after this token.

I am unsure about the variable naming, especially about "IsListNumber".   I would be happy about a review :)